### PR TITLE
#46 Move `@babel/runtime` from runtime to development dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1094,6 +1094,7 @@
       "version": "7.11.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
       "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -7417,7 +7418,8 @@
     "regenerator-runtime": {
       "version": "0.13.7",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.14.5",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "private": true,
   "homepage": "https://github.com/bookmate/everybook-ios#readme",
   "dependencies": {
-    "@babel/runtime": "^7.11.2",
     "aws-sdk": "^2.734.0",
     "commander": "^6.0.0",
     "looks-same": "^7.2.3",
@@ -39,6 +38,7 @@
     "@babel/plugin-transform-runtime": "^7.11.0",
     "@babel/preset-env": "^7.11.0",
     "@babel/register": "^7.11.5",
+    "@babel/runtime": "^7.11.2",
     "babel-jest": "^26.3.0",
     "babel-loader": "^8.1.0",
     "gulp": "^4.0.2",


### PR DESCRIPTION
Fixes #46
