### PR TITLE
#129 Checkout repository with higher `fetch-depth` value

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 100
       - run: npm ci
       - run: npm test
       - run: npx gulp

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@del-systems/swatcher",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Screenshot Watcher",
   "main": "src/index.js",
   "scripts": {

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-export default '1.2.1'
+export default '1.2.2'


### PR DESCRIPTION
### Issue
Fixes #129

### Summary
Codecov log was printing this. Increased `fetch-depth` as it was requested by Codecov.
```console
->  Issue detecting commit SHA. Please run actions/checkout with fetch-depth > 1 or set to 0
```
